### PR TITLE
EIT-2658 | [Python] Fix Network enum was starting from 1

### DIFF
--- a/languages/python/bloock/client/client.py
+++ b/languages/python/bloock/client/client.py
@@ -32,7 +32,7 @@ class Client:
         self.config_data.config.host = host
 
     def set_network_config(self, network: Network, config: NetworkConfig):
-        self.config_data.networks_config[int(network)].CopyFrom(config)
+        self.config_data.networks_config[Network.to_proto(network)].CopyFrom(config)
 
     def send_records(self, records: List[str]) -> List[RecordReceipt]:
         res = self.bridge_client.record().SendRecords(
@@ -85,12 +85,14 @@ class Client:
 
         return res.record
 
-    def verify_records(self, records: List[str], network=Network.BLOOCK_CHAIN) -> int:
+    def verify_records(
+        self, records: List[str], network: Network = Network.BLOOCK_CHAIN
+    ) -> int:
         res = self.bridge_client.proof().VerifyRecords(
             VerifyRecordsRequest(
                 config_data=self.config_data,
                 records=records,
-                network=NetworkProto.ValueType(int(network)),
+                network=Network.to_proto(network),
             )
         )
 
@@ -104,7 +106,7 @@ class Client:
             ValidateRootRequest(
                 config_data=self.config_data,
                 root=root,
-                network=NetworkProto.ValueType(int(network)),
+                network=Network.to_proto(network),
             )
         )
 

--- a/languages/python/bloock/client/entity/network.py
+++ b/languages/python/bloock/client/entity/network.py
@@ -3,11 +3,11 @@ from bloock._bridge.proto.config_pb2 import Network as NetworkProto
 
 
 class Network(Enum):
-    ETHEREUM_MAINNET = 1
-    ETHEREUM_RINKEBY = 2
-    ETHEREUM_GOERLI = 3
-    GNOSIS_CHAIN = 4
-    BLOOCK_CHAIN = 5
+    ETHEREUM_MAINNET = 0
+    ETHEREUM_RINKEBY = 1
+    ETHEREUM_GOERLI = 2
+    GNOSIS_CHAIN = 3
+    BLOOCK_CHAIN = 4
 
     @classmethod
     def from_proto(cls, network: NetworkProto):

--- a/languages/python/bloock/client/entity/network.py
+++ b/languages/python/bloock/client/entity/network.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from enum import Enum
 from bloock._bridge.proto.config_pb2 import Network as NetworkProto
 
@@ -9,9 +10,18 @@ class Network(Enum):
     GNOSIS_CHAIN = 3
     BLOOCK_CHAIN = 4
 
-    @classmethod
-    def from_proto(cls, network: NetworkProto):
-        return cls(network)
-
     def __int__(self):
         return self.value
+
+    @staticmethod
+    def to_proto(network: Network) -> NetworkProto.ValueType:
+        if network == Network.ETHEREUM_MAINNET:
+            return NetworkProto.ETHEREUM_MAINNET
+        elif network == Network.ETHEREUM_RINKEBY:
+            return NetworkProto.ETHEREUM_RINKEBY
+        elif network == Network.ETHEREUM_GOERLI:
+            return NetworkProto.ETHEREUM_GOERLI
+        elif network == Network.GNOSIS_CHAIN:
+            return NetworkProto.GNOSIS_CHAIN
+        elif network == Network.BLOOCK_CHAIN:
+            return NetworkProto.BLOOCK_CHAIN

--- a/languages/python/test/test_end_to_end.py
+++ b/languages/python/test/test_end_to_end.py
@@ -1,9 +1,10 @@
 import os
 import unittest
-from bloock._bridge.proto.config_pb2 import Network
+
 from bloock.client.builder import RecordBuilder
 from bloock.client.client import Client
 from bloock.client.entity.signer import EcsdaSigner
+from bloock.client.entity.network import Network
 
 
 class TestE2E(unittest.TestCase):


### PR DESCRIPTION
Al provar a veure si s'havia solucionat lo dels imports, he trobat que hi havia un bug en el mapping de l'entitat Network a proto de python. Simplement era l'index de l'enum que era diferent que el de proto.